### PR TITLE
Update fdfs_storaged.service, fix typo.

### DIFF
--- a/systemd/fdfs_storaged.service
+++ b/systemd/fdfs_storaged.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
-PIDFile=/opt/fastcfs/data/fdfs_storaged.pid
+PIDFile=/opt/fastdfs/data/fdfs_storaged.pid
 ExecStart=/usr/bin/fdfs_storaged /etc/fdfs/storage.conf restart
 
 # No artificial start/stop timeout


### PR DESCRIPTION
By the way, I would like to know how the pid directory is specified when fdfs storaged 5.10 is started?