### PR TITLE
fix: possible out-of-bounds issues with array access

### DIFF
--- a/test/test_upload.c
+++ b/test/test_upload.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		if (files[file_index].upload_count >= files[file_index].count)
+		if (file_index >= FILE_TYPE_COUNT || files[file_index].upload_count >= files[file_index].count)
 		{
 			continue;
 		}


### PR DESCRIPTION
for (file_index=0; file_index<FILE_TYPE_COUNT; file_index++)
file_index may be 6
Array 'files[6]' accessed at index 6 which is out of bounds. 