### PR TITLE
fix: fix realloc mistakes to avoid memory leaks

### DIFF
--- a/storage/fdht_client/fdht_func.c
+++ b/storage/fdht_client/fdht_func.c
@@ -226,9 +226,9 @@ int fdht_split_ids(const char *szIds, int **ppIds, int *id_count)
 		if (alloc_count < *id_count + (count + 1))
 		{
 			alloc_count += count + 1;
-			*ppIds = (int *)realloc(*ppIds, \
+            int *new_ids = (int *)realloc(*ppIds, \
 				sizeof(int) * alloc_count);
-			if (*ppIds == NULL)
+			if (new_ids == NULL)
 			{
 				result = errno != 0 ? errno : ENOMEM;
 				logError("file: "__FILE__", line: %d, "\
@@ -237,9 +237,11 @@ int fdht_split_ids(const char *szIds, int **ppIds, int *id_count)
 					__LINE__, \
 					(int)sizeof(int) * alloc_count,\
 					result, STRERROR(result));
-
+                free(*ppIds)
+                *ppIds = NULL;
 				break;
 			}
+            *ppIds = new_ids;
 		}
 
 		for (i=nStart; i<=nEnd; i++)
@@ -498,11 +500,11 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 					alloc_server_count = \
 						pGroupArray->server_count + \
 						pGroupArray->group_count + 8;
-					pGroupArray->servers = (FDHTServerInfo*)
+                    FDHTServerInfo* new_servers = (FDHTServerInfo*)
 						realloc(pGroupArray->servers, \
 						sizeof(FDHTServerInfo) * \
 						alloc_server_count);
-					if (pGroupArray->servers == NULL)
+					if (new_servers == NULL)
 					{
 						logError("file: "__FILE__", " \
 							"line: %d, malloc " \
@@ -513,8 +515,11 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 							(int)sizeof(FDHTServerInfo) \
 							 * alloc_server_count, \
 							errno, STRERROR(errno));
+                        free(pGroupArray->servers);
+                        pGroupArray->servers = NULL;
 						return errno!=0 ? errno:ENOMEM;
 					}
+                    pGroupArray->servers = new_servers;
 				}
 
 				fdht_insert_sorted_servers( \
@@ -574,10 +579,10 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 
 	if (alloc_server_count > pGroupArray->server_count)
 	{
-		pGroupArray->servers = (FDHTServerInfo*)realloc( \
+		FDHTServerInfo* new_servers= (FDHTServerInfo*)realloc( \
 				pGroupArray->servers, sizeof(FDHTServerInfo) \
 				* pGroupArray->server_count);
-		if (pGroupArray->servers == NULL)
+		if (new_servers == NULL)
 		{
 			logError("file: "__FILE__", line: %d, " \
 				"malloc %d bytes fail, " \
@@ -585,8 +590,11 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 				__LINE__, (int)sizeof(FDHTServerInfo) * \
 				pGroupArray->server_count, \
 				errno, STRERROR(errno));
+            free(pGroupArray->servers);
+            pGroupArray->servers = NULL;
 			return errno != 0 ? errno : ENOMEM;
 		}
+        pGroupArray->servers = new_servers;
 	}
 
 	memset(&pGroupArray->proxy_server, 0, sizeof(FDHTServerInfo));

--- a/storage/storage_sync.c
+++ b/storage/storage_sync.c
@@ -3320,17 +3320,20 @@ int storage_sync_thread_start(const FDFSStorageBrief *pStorage)
 	}
 
     thread_count = FC_ATOMIC_INC(g_storage_sync_thread_count);
-	sync_tids = (pthread_t *)realloc(sync_tids,
+    pthread_t *new_sync_tids = (pthread_t *)realloc(sync_tids,
             sizeof(pthread_t) * thread_count);
-	if (sync_tids == NULL)
+	if (new_sync_tids == NULL)
 	{
 		logError("file: "__FILE__", line: %d, "
 			"malloc %d bytes fail, errno: %d, error info: %s",
 			__LINE__, (int)sizeof(pthread_t) * thread_count,
             errno, STRERROR(errno));
+        free(sync_tids);
+        sync_tids = NULL;
 	}
 	else
 	{
+        sync_tids = new_sync_tids;
 		sync_tids[thread_count - 1] = tid;
 	}
 

--- a/tracker/tracker_mem.c
+++ b/tracker/tracker_mem.c
@@ -655,18 +655,21 @@ static int tracker_load_groups_new(FDFSGroups *pGroups, const char *data_path,
 		if (nStorageSyncSize <= *nTrunkServerCount)
 		{
 			nStorageSyncSize += 8;
-			*ppTrunkServers = (FDFSStorageSync *)realloc( \
-				*ppTrunkServers, \
-				sizeof(FDFSStorageSync) * nStorageSyncSize);
-			if (*ppTrunkServers == NULL)
+            FDFSStorageSync *new_trunk_servers = (FDFSStorageSync *)
+                    realloc(*ppTrunkServers, \
+                    sizeof(FDFSStorageSync) * nStorageSyncSize);
+			if (new_trunk_servers == NULL)
 			{
 				result = errno != 0 ? errno : ENOMEM;
 				logError("file: "__FILE__", line: %d, " \
 					"realloc %d bytes fail", __LINE__, \
 					(int)sizeof(FDFSStorageSync) * \
 					nStorageSyncSize);
+                free(*ppTrunkServers);
+                *ppTrunkServers = NULL;
 				break;
 			}
+            *ppTrunkServers = new_trunk_servers;
 		}
 
 		strcpy((*ppTrunkServers)[*nTrunkServerCount].group_name, \
@@ -991,18 +994,21 @@ static int tracker_load_storages_old(FDFSGroups *pGroups, const char *data_path)
 		if (nStorageSyncSize <= nStorageSyncCount)
 		{
 			nStorageSyncSize += 8;
-			pStorageSyncs = (FDFSStorageSync *)realloc( \
-				pStorageSyncs, \
-				sizeof(FDFSStorageSync) * nStorageSyncSize);
-			if (pStorageSyncs == NULL)
+            FDFSStorageSync *pNewStorageSyncs = (FDFSStorageSync *)
+                    realloc(pStorageSyncs, \
+                    sizeof(FDFSStorageSync) * nStorageSyncSize);
+			if (pNewStorageSyncs == NULL)
 			{
 				result = errno != 0 ? errno : ENOMEM;
 				logError("file: "__FILE__", line: %d, " \
 					"realloc %d bytes fail", __LINE__, \
 					(int)sizeof(FDFSStorageSync) * \
 					nStorageSyncSize);
+                free(pStorageSyncs);
+                pStorageSyncs = NULL;
 				break;
 			}
+            pStorageSyncs = pNewStorageSyncs;
 		}
 
 		strcpy(pStorageSyncs[nStorageSyncCount].group_name, \
@@ -1274,18 +1280,21 @@ static int tracker_load_storages_new(FDFSGroups *pGroups, const char *data_path)
 			{
 				nStorageSyncSize *= 2;
 			}
-			pStorageSyncs = (FDFSStorageSync *)realloc( \
-				pStorageSyncs, \
-				sizeof(FDFSStorageSync) * nStorageSyncSize);
-			if (pStorageSyncs == NULL)
+            FDFSStorageSync *pNewStorageSyncs = (FDFSStorageSync *)
+                    realloc(pStorageSyncs, \
+                    sizeof(FDFSStorageSync) * nStorageSyncSize);
+			if (pNewStorageSyncs == NULL)
 			{
 				result = errno != 0 ? errno : ENOMEM;
 				logError("file: "__FILE__", line: %d, " \
 					"realloc %d bytes fail", __LINE__, \
 					(int)sizeof(FDFSStorageSync) * \
 					nStorageSyncSize);
+                free(pStorageSyncs);
+                pStorageSyncs = NULL;
 				break;
 			}
+            pStorageSyncs = pNewStorageSyncs;
 		}
 
 		strcpy(pStorageSyncs[nStorageSyncCount].group_name, \


### PR DESCRIPTION
There are some issues with the use of realloc, where the pointer was nulled but not freed upon failure. This change fixes issues by ensuring that the pointer is freed when realloc fails, preventing potential memory leaks. 