### PR TITLE
Added: 增加IPv6支持

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -16,9 +16,13 @@ base_path = /opt/fastdfs
 #   and the HOST can be dual IPs or hostnames seperated by comma,
 #   the dual IPS must be an inner (intranet) IP and an outer (extranet) IP,
 #   or two different types of inner (intranet) IPs.
+#   IPv4:
 #   for example: 192.168.2.100,122.244.141.46:22122
 #   another eg.: 192.168.1.10,172.17.4.21:22122
-
+#
+#   IPv6:
+#    for example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e,fe80::1ee9:90a8:1351:436c]:22122
+#
 tracker_server = 192.168.0.196:22122
 tracker_server = 192.168.0.197:22122
 

--- a/conf/storage.conf
+++ b/conf/storage.conf
@@ -12,6 +12,11 @@ group_name = group1
 
 # bind an address of this host
 # empty for bind all addresses of this host
+# IPv4:
+# for example: 192.168.2.100
+#
+# IPv6:
+# or example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e]
 bind_addr =
 
 # if bind an address of this host when connect to other servers 
@@ -139,9 +144,13 @@ subdir_count_per_path = 256
 #   and the HOST can be dual IPs or hostnames seperated by comma,
 #   the dual IPS must be an inner (intranet) IP and an outer (extranet) IP,
 #   or two different types of inner (intranet) IPs.
+#   IPv4:
 #   for example: 192.168.2.100,122.244.141.46:22122
 #   another eg.: 192.168.1.10,172.17.4.21:22122
-
+#
+#   IPv6:
+#    for example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e,fe80::1ee9:90a8:1351:436c]:22122
+#
 tracker_server = 192.168.209.121:22122
 tracker_server = 192.168.209.122:22122
 

--- a/conf/storage_ids.conf
+++ b/conf/storage_ids.conf
@@ -6,11 +6,17 @@
 # storage ip or hostname can be dual IPs seperated by comma,
 # one is an inner (intranet) IP and another is an outer (extranet) IP,
 # or two different types of inner (intranet) IPs
+# IPv4:
 # for example: 192.168.2.100,122.244.141.46
 # another eg.: 192.168.1.10,172.17.4.21
+#
+# IPv6:
+# or example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e,fe80::1ee9:90a8:1351:436c]
+# another eg.:  [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e,fe80::1ee9:90a8:1351:436c]:100002
 #
 # the port is optional. if you run more than one storaged instances
 # in a server, you must specified the port to distinguish different instances.
 
 100001   group1  192.168.0.196
 100002   group1  192.168.0.197
+100003   group1  [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e]:100002

--- a/conf/tracker.conf
+++ b/conf/tracker.conf
@@ -5,6 +5,11 @@ disabled = false
 
 # bind an address of this host
 # empty for bind all addresses of this host
+# IPv4:
+# for example: 192.168.2.100
+#
+# IPv6:
+# or example: [2409:8a20:42d:2f40:587a:4c47:72c0:ad8e]
 bind_addr =
 
 # the tracker server port

--- a/storage/fdht_client/fdht_func.c
+++ b/storage/fdht_client/fdht_func.c
@@ -22,6 +22,7 @@
 #include <time.h>
 #include "fastcommon/logger.h"
 #include "fastcommon/sockopt.h"
+#include "fastcommon/local_ip_func.h"
 #include "fastcommon/shared_func.h"
 #include "fastcommon/ini_file_reader.h"
 #include "fdht_func.h"
@@ -448,7 +449,7 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 		pItemEnd = pItemInfo + pServerArray->count;
 		for (; pItemInfo<pItemEnd; pItemInfo++)
 		{
-			if (splitEx(pItemInfo->value, ':', ip_port, 2) != 2)
+			if (parseAddress(pItemInfo->value, ip_port) !=2 )
 			{
 				logError("file: "__FILE__", line: %d, " \
 					"\"%s\" 's value \"%s\" is invalid, "\
@@ -468,12 +469,13 @@ int fdht_load_groups_ex(IniContext *pIniContext, \
 				return EINVAL;
 			}
 
-			if (strcmp(pServerInfo->ip_addr, "127.0.0.1") == 0)
+			if (strcmp(pServerInfo->ip_addr, LOCAL_LOOPBACK_IPv4) == 0 ||
+				strcmp(pServerInfo->ip_addr, LOCAL_LOOPBACK_IPv6) ==0 )
 			{
 				logError("file: "__FILE__", line: %d, " \
 					"group%d: invalid hostname \"%s\", " \
-					"ip address can not be 127.0.0.1!", \
-					__LINE__, group_id, pItemInfo->value);
+					"ip address can not be %s!", \
+					__LINE__, group_id, pItemInfo->value, pServerInfo->ip_addr);
 				return EINVAL;
 			}
 

--- a/storage/fdht_client/fdht_proto.c
+++ b/storage/fdht_client/fdht_proto.c
@@ -172,7 +172,15 @@ int fdht_connect_server_nb(FDHTServerInfo *pServer, const int connect_timeout)
 	{
 		close(pServer->sock);
 	}
-	pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+
+    // 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    if (is_ipv6_addr(pServer->ip_addr))     
+    {
+        pServer->sock = socket(AF_INET6, SOCK_STREAM, 0);
+    }else{
+        pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+    }
+
 	if(pServer->sock < 0)
 	{
 		logError("file: "__FILE__", line: %d, " \
@@ -213,7 +221,15 @@ int fdht_connect_server(FDHTServerInfo *pServer)
 	{
 		close(pServer->sock);
 	}
-	pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+
+    // 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    if (is_ipv6_addr(pServer->ip_addr))     
+    {
+        pServer->sock = socket(AF_INET6, SOCK_STREAM, 0);
+    }else{
+        pServer->sock = socket(AF_INET, SOCK_STREAM, 0);
+    }
+
 	if(pServer->sock < 0)
 	{
 		logError("file: "__FILE__", line: %d, " \

--- a/storage/storage_global.c
+++ b/storage/storage_global.c
@@ -69,7 +69,7 @@ FDFSMultiIP g_last_storage_ip = {0, 0};	  //the last storage ip address
 
 LogContext g_access_log_context = {LOG_INFO, STDERR_FILENO, NULL};
 
-in_addr_t g_server_id_in_filename = 0;
+in_addr_64_t g_server_id_in_filename = 0;
 bool g_use_access_log = false;    //if log to access log
 bool g_rotate_access_log = false; //if rotate the access log every day
 bool g_compress_old_access_log = false; //if compress the old access log
@@ -82,7 +82,7 @@ byte g_file_signature_method = STORAGE_FILE_SIGNATURE_METHOD_HASH;
 char g_key_namespace[FDHT_MAX_NAMESPACE_LEN+1] = {0};
 int g_namespace_len = 0;
 int g_allow_ip_count = 0;
-in_addr_t *g_allow_ip_addrs = NULL;
+in_addr_64_t *g_allow_ip_addrs = NULL;
 StorageStatusPerTracker *g_my_report_status = NULL;  //returned by tracker server
 
 TimeInfo g_access_log_rotate_time = {0, 0}; //rotate access log time base

--- a/storage/storage_global.h
+++ b/storage/storage_global.h
@@ -100,7 +100,7 @@ extern FDFSMultiIP g_last_storage_ip;	//the last storage ip address
 
 extern LogContext g_access_log_context;
 
-extern in_addr_t g_server_id_in_filename;
+extern in_addr_64_t g_server_id_in_filename;
 extern bool g_store_slave_file_use_link; //if store slave file use symbol link
 extern bool g_use_storage_id;  //identify storage by ID instead of IP address
 extern byte g_id_type_in_filename; //id type of the storage server in the filename
@@ -116,7 +116,7 @@ extern char g_key_namespace[FDHT_MAX_NAMESPACE_LEN+1];
 extern int g_namespace_len;
 
 extern int g_allow_ip_count;  /* -1 means match any ip address */
-extern in_addr_t *g_allow_ip_addrs;  /* sorted array, asc order */
+extern in_addr_64_t *g_allow_ip_addrs;  /* sorted array, asc order */
 
 extern StorageStatusPerTracker *g_my_report_status;  //returned by tracker server
 

--- a/storage/storage_service.c
+++ b/storage/storage_service.c
@@ -1568,12 +1568,12 @@ int storage_set_body_length(struct fast_task_info *pTask)
 }
 
 static int sock_accept_done_callback(struct fast_task_info *task,
-        const in_addr_t client_addr, const bool bInnerPort)
+        const in_addr_64_t client_addr, const bool bInnerPort)
 {
     if (g_allow_ip_count >= 0)
     {
         if (bsearch(&client_addr, g_allow_ip_addrs,
-                    g_allow_ip_count, sizeof(in_addr_t),
+                    g_allow_ip_count, sizeof(in_addr_64_t),
                     cmp_by_ip_addr_t) == NULL)
         {
             logError("file: "__FILE__", line: %d, "

--- a/tracker/fdfs_server_id_func.c
+++ b/tracker/fdfs_server_id_func.c
@@ -319,6 +319,7 @@ int fdfs_load_storage_ids(char *content, const char *pStorageIdsFilename)
 	char *group_name;
 	char *pHost;
 	char *pPort;
+	char *pTmp;
 	FDFSStorageIdInfo *pStorageIdInfo;
     char error_info[256];
 	int alloc_bytes;
@@ -428,18 +429,33 @@ int fdfs_load_storage_ids(char *content, const char *pStorageIdsFilename)
 			{
 				pHost++;
 			}
+			
+			// 处理IPv6的前'['括号的问题
+            pTmp = strchr(pHost, '[');
+			if (pTmp != NULL)
+			{
+				pHost++;
+			}
 
-            pPort = strchr(pHost, ':');
-            if (pPort != NULL)
-            {
-                *pPort = '\0';
-                pStorageIdInfo->port = atoi(pPort + 1);
-            }
-            else
-            {
-                pStorageIdInfo->port = 0;
-            }
-
+			pPort = strchr(pHost, ']'); 
+			if(pPort != NULL){
+				*pPort = '\0';
+				pPort++;   // ]
+				pPort++;   // :
+				pStorageIdInfo->port = atoi(pPort + 1);
+			}else {
+	            pPort = strchr(pHost, ':');
+     	    	if (pPort != NULL)
+     	    	{
+     	           *pPort = '\0';
+     	           pStorageIdInfo->port = atoi(pPort + 1);
+     	    	}
+     	    	else
+      	    	{
+      	          pStorageIdInfo->port = 0;
+      	    	}
+			}
+			
             if ((result=fdfs_parse_multi_ips(pHost, &pStorageIdInfo->ip_addrs,
                             error_info, sizeof(error_info))) != 0)
             {

--- a/tracker/fdfs_shared_func.h
+++ b/tracker/fdfs_shared_func.h
@@ -167,6 +167,8 @@ void fdfs_set_server_info(TrackerServerInfo *pServer,
 void fdfs_set_server_info_ex(TrackerServerInfo *pServer,
         const FDFSMultiIP *ip_addrs, const int port);
 
+char* fdfs_ip_to_shortcode(const char* ipAddr, int shortCodeLength);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tracker/tracker_global.c
+++ b/tracker/tracker_global.c
@@ -17,7 +17,7 @@ FDFSStorageReservedSpace g_storage_reserved_space = { \
 		TRACKER_STORAGE_RESERVED_SPACE_FLAG_MB};
 
 int g_allow_ip_count = 0;
-in_addr_t *g_allow_ip_addrs = NULL;
+in_addr_64_t *g_allow_ip_addrs = NULL;
 
 struct base64_context g_base64_context;
 

--- a/tracker/tracker_global.h
+++ b/tracker/tracker_global.h
@@ -43,7 +43,7 @@ extern FDFSStorageReservedSpace g_storage_reserved_space;
 extern int g_check_active_interval; //check storage server alive every interval seconds
 
 extern int g_allow_ip_count;  /* -1 means match any ip address */
-extern in_addr_t *g_allow_ip_addrs;  /* sorted array, asc order */
+extern in_addr_64_t *g_allow_ip_addrs;  /* sorted array, asc order */
 extern struct base64_context g_base64_context;
 
 extern bool g_storage_ip_changed_auto_adjust;

--- a/tracker/tracker_mem.c
+++ b/tracker/tracker_mem.c
@@ -3182,6 +3182,10 @@ static FDFSStorageDetail *tracker_mem_get_active_http_server_by_ip( \
 	if (!g_use_storage_id)
 	{
 		strcpy(target_storage.id, ip_addr);
+		// 当IP地址为IPv6时，其storage_id值为IP地址的short code
+		if(is_ipv6_addr(ip_addr)){
+			strcpy(target_storage.id, fdfs_ip_to_shortcode(ip_addr, FDFS_DEFAULT_STORAGE_ID_LEN));
+		}
 	}
 	else
 	{
@@ -3255,6 +3259,10 @@ FDFSStorageDetail *tracker_mem_get_storage_by_ip(FDFSGroupInfo *pGroup, \
 	else
 	{
 		storage_id = ip_addr;
+		// 当IP地址为IPv6时，其storage_id值为IP地址的short code
+		if(is_ipv6_addr(ip_addr)){
+			storage_id = fdfs_ip_to_shortcode(ip_addr, FDFS_DEFAULT_STORAGE_ID_LEN);
+		}
 	}
 
 	return tracker_mem_get_storage(pGroup, storage_id);
@@ -3719,6 +3727,10 @@ static int _tracker_mem_add_storage(FDFSGroupInfo *pGroup,
 	else
 	{
 		storage_id = ip_addr;
+		// 当IP地址为IPv6时，其storage_id值为IP地址的short code
+		if(is_ipv6_addr(ip_addr)){
+			storage_id = fdfs_ip_to_shortcode(ip_addr, FDFS_DEFAULT_STORAGE_ID_LEN);
+		}		
 	}
 
 	if (bNeedLock && (result=pthread_mutex_lock(&mem_thread_lock)) != 0)
@@ -4496,6 +4508,11 @@ int tracker_mem_add_group_and_storage(TrackerClientInfo *pClientInfo, \
 	{
 		pStorageIdInfo = NULL;
 		storage_id = ip_addr;
+		// 当IP地址为IPv6时，其storage_id值为IP地址的short code
+		if(is_ipv6_addr(ip_addr)){
+			storage_id = fdfs_ip_to_shortcode(ip_addr, FDFS_DEFAULT_STORAGE_ID_LEN);
+		}
+
 	}
 
 	if (pClientInfo->pGroup->storage_port == 0)

--- a/tracker/tracker_types.h
+++ b/tracker/tracker_types.h
@@ -36,6 +36,8 @@
 #define FDFS_TRUNK_FILE_INFO_LEN  16
 #define FDFS_MAX_SERVER_ID        ((1 << 24) - 1)
 
+#define FDFS_DEFAULT_STORAGE_ID_LEN  6
+
 #define FDFS_ID_TYPE_SERVER_ID    1
 #define FDFS_ID_TYPE_IP_ADDRESS   2
 


### PR DESCRIPTION
1、增加配置文件解析IPv6地址的能力。
2、修改配置文件增加IPv6配置说明。
3、修改fdht客户端增加IPv6支持。
4、增加IPv6长地址编码成短地址的功能，解决storage id使用IPv6地址时，会截取IPv6的前16位字符串时产生的不唯一问题。