### PR TITLE
feat(config): add store_path#_readonly setting to limit write access per storage path

### DIFF
--- a/conf/storage.conf
+++ b/conf/storage.conf
@@ -159,6 +159,14 @@ store_path_count = 1
 store_path0 = /opt/fastdfs
 #store_path1 = /opt/fastdfs2
 
+# store_path#_readonly (0-based index) - configures whether new files can be added to this store path.
+# if store_path#_readonly not exists, it's value is false
+#
+# IMPORTANT NOTE:
+# it doesn't make the filesystem read-only. It only controls whether new files can be added to the specified store path. Existing files in store_path can still be read normally.
+
+#store_path0_readonly = false
+
 # subdir_count  * subdir_count directories will be auto created under each 
 # store_path (disk), value can be 1 to 256, default value is 256
 subdir_count_per_path = 256

--- a/storage/tracker_client_thread.c
+++ b/storage/tracker_client_thread.c
@@ -2284,7 +2284,12 @@ static int tracker_report_df_stat(ConnectionInfo *pTrackerServer,
 		store_path_index = -1;
 		for (i=0; i<g_fdfs_store_paths.count; i++)
 		{
-			if (g_fdfs_store_paths.paths[i].free_mb > \
+			if (g_fdfs_store_paths.paths[i].read_only)
+        	{
+            	continue;
+        	}
+			
+			if (!g_fdfs_store_paths.paths[i].read_only && g_fdfs_store_paths.paths[i].free_mb > \
 				g_avg_storage_reserved_mb \
 				&& g_fdfs_store_paths.paths[i].free_mb > max_free_mb)
 			{

--- a/storage/trunk_mgr/trunk_shared.c
+++ b/storage/trunk_mgr/trunk_shared.c
@@ -51,6 +51,7 @@ FDFSStorePathInfo *storage_load_paths_from_conf_file_ex(
 	char item_name[64];
 	FDFSStorePathInfo *store_paths;
 	char *pPath;
+	bool Readonly = false;
     int bytes;
 	int i;
 
@@ -93,9 +94,11 @@ FDFSStorePathInfo *storage_load_paths_from_conf_file_ex(
 
 		pPath = SF_G_BASE_PATH_STR;
 	}
+	Readonly = iniGetBoolValue(szSectionName, "store_path0_readonly", pItemContext, false);
 
     store_paths[0].path_len = strlen(pPath);
 	store_paths[0].path = strdup(pPath);
+	store_paths[0].read_only = Readonly;
 	if (store_paths[0].path == NULL)
 	{
 		logError("file: "__FILE__", line: %d, "
@@ -122,6 +125,9 @@ FDFSStorePathInfo *storage_load_paths_from_conf_file_ex(
 			*err_no = ENOENT;
 			break;
 		}
+		sprintf(item_name, "store_path%d_readonly", i);
+        Readonly = iniGetBoolValue(szSectionName, item_name,
+                   pItemContext, false);
 
 		chopPath(pPath);
 		if (!fileExists(pPath))
@@ -144,6 +150,7 @@ FDFSStorePathInfo *storage_load_paths_from_conf_file_ex(
 
         store_paths[i].path_len = strlen(pPath);
 		store_paths[i].path = strdup(pPath);
+		store_paths[i].read_only = Readonly;
 		if (store_paths[i].path == NULL)
 		{
 			logError("file: "__FILE__", line: %d, " \

--- a/storage/trunk_mgr/trunk_shared.h
+++ b/storage/trunk_mgr/trunk_shared.h
@@ -55,6 +55,7 @@ typedef struct
     int path_len;  //the length of store path
 	char *path;    //file store path
     char *mark;    //path mark to avoid confusion
+    bool read_only; //path marked to read only
 } FDFSStorePathInfo;
 
 typedef struct {


### PR DESCRIPTION
- Adds configuration option to mark specific storage paths as read-only
- Prevents new file creation while maintaining read access to existing files
- Useful for maintenance, migration and disk space management

这个PR基于项目实践，在具体项目中会遇到存储扩容缩容迁移的情况。
场景举例：1T的存储迁移到2T的存储，需要保证store0_path仍设置在1T存储上，但不要往上写文件了，文件往store1_path写。然后挂载2T存储到临时目录，并且把文件复制到2T存储里。后续进行一个挂载调整，把2T存储挂载为store0_path。不再使用1T存储。

故此进行了一个store_path只读功能的开发。新增加一个配置项标记特定store_path为readonly，此标记仅表示不往该store_path存储文件，而非文件系统意义上的只读。实现方法是在配置标记后，在选取store_path_index相关代码里跳过这个store_path。