### PR TITLE
fix typos in some files

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -545,7 +545,7 @@ Version 2.03  2010-11-08
 
 Version 2.02  2010-10-28
  * get parameters function from tracker server changed, 
-   add paramter: storage_sync_file_max_delay
+   add parameter: storage_sync_file_max_delay
  * local ip functions move to common/local_ip_func.c
  * when query all storage servers to store, do not increase the current
    write server index

--- a/INSTALL
+++ b/INSTALL
@@ -126,7 +126,7 @@ memo:
      # notice
      # info
      # debug
-   * allow_hosts can ocur more than once, host can be hostname or ip address,
+   * allow_hosts can occur more than once, host can be hostname or ip address,
      "*" means match all ip addresses, can use range like this: 10.0.1.[1-15,20]
       or host[01-08,20-25].domain.com, for example:
         allow_hosts=10.0.1.[1-15,20]
@@ -160,7 +160,7 @@ memo:
     when store_lookup set to 1(specify group), 
     store_group must be set to a specified group name.
   * reserved_storage_space is the reserved storage space for system 
-    or other applications. if the free(available) space of any stoarge
+    or other applications. if the free(available) space of any storage
     server in a group <= reserved_storage_space, no file can be uploaded
     to this group (since V1.1)
     bytes unit can be one of follows:
@@ -209,7 +209,7 @@ memo:
 -------------------------------------------------
 
 memo:
-  * tracker_server can ocur more than once, and tracker_server format is
+  * tracker_server can occur more than once, and tracker_server format is
     "host:port", host can be hostname or ip address.
   * store_path#, # for digital, based 0
   * check_file_duplicate: when set to true, must work with FastDHT server, 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The tracker and storage contain one or more servers. The servers in the tracker
 or storage cluster can be added to or removed from the cluster by any time without
 affecting the online services. The servers in the tracker cluster are peer to peer.
 
-The storarge servers organizing by the file group to obtain high capacity.
+The storage servers organizing by the file group to obtain high capacity.
 The storage system contains one or more groups whose files are independent among
 these groups. The capacity of the whole storage system equals to the sum of all
 groups' capacity. A file group contains one or more storage servers whose files
@@ -42,7 +42,7 @@ group, files already existing in this group are replicated to this new server
 automatically, and when this replication done, system will switch this server
 online to providing storage services.
 
-When the whole storage capacity is insufficiency, you can add one or more
+When the whole storage capacity is insufficient, you can add one or more
 groups to expand the storage capacity. To do this, you need to add one or
 more storage servers.
 

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/mod_fastdfs.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/mod_fastdfs.conf
@@ -85,7 +85,7 @@ response_mode=proxy
 
 # the NIC alias prefix, such as eth in Linux, you can see it by ifconfig -a
 # multi aliases split by comma. empty value means auto set by OS type
-# this paramter used to get all ip address of the local host
+# this parameter used to get all ip address of the local host
 # default values is empty
 if_alias_prefix=
 

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/storage_ids.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/storage_ids.conf
@@ -3,7 +3,7 @@
 # id is a natural number (1, 2, 3 etc.),
 # 6 bits of the id length is enough, such as 100001
 #
-# storage ip or hostname can be dual IPs seperated by comma,
+# storage ip or hostname can be dual IPs separated by comma,
 # one is an inner (intranet) IP and another is an outer (extranet) IP,
 # or two different types of inner (intranet) IPs
 # for example: 192.168.2.100,122.244.141.46

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/tracker.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.8/conf/tracker.conf
@@ -255,7 +255,7 @@ storage_ids_filename = storage_ids.conf
 # id type of the storage server in the filename, values are:
 ## ip: the ip address of the storage server
 ## id: the server id of the storage server
-# this paramter is valid only when use_storage_id set to true
+# this parameter is valid only when use_storage_id set to true
 # default value is ip
 # since V4.03
 id_type_in_filename = id

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/mod_fastdfs.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/mod_fastdfs.conf
@@ -85,7 +85,7 @@ response_mode=proxy
 
 # the NIC alias prefix, such as eth in Linux, you can see it by ifconfig -a
 # multi aliases split by comma. empty value means auto set by OS type
-# this paramter used to get all ip address of the local host
+# this parameter used to get all ip address of the local host
 # default values is empty
 if_alias_prefix=
 

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/storage_ids.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/storage_ids.conf
@@ -3,7 +3,7 @@
 # id is a natural number (1, 2, 3 etc.),
 # 6 bits of the id length is enough, such as 100001
 #
-# storage ip or hostname can be dual IPs seperated by comma,
+# storage ip or hostname can be dual IPs separated by comma,
 # one is an inner (intranet) IP and another is an outer (extranet) IP,
 # or two different types of inner (intranet) IPs
 # for example: 192.168.2.100,122.244.141.46

--- a/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/tracker.conf
+++ b/docker/dockerfile_local-v6.0.9/build_image-v6.0.9/conf/tracker.conf
@@ -255,7 +255,7 @@ storage_ids_filename = storage_ids.conf
 # id type of the storage server in the filename, values are:
 ## ip: the ip address of the storage server
 ## id: the server id of the storage server
-# this paramter is valid only when use_storage_id set to true
+# this parameter is valid only when use_storage_id set to true
 # default value is ip
 # since V4.03
 id_type_in_filename = id

--- a/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/mod_fastdfs.conf
+++ b/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/mod_fastdfs.conf
@@ -85,7 +85,7 @@ response_mode=proxy
 
 # the NIC alias prefix, such as eth in Linux, you can see it by ifconfig -a
 # multi aliases split by comma. empty value means auto set by OS type
-# this paramter used to get all ip address of the local host
+# this parameter used to get all ip address of the local host
 # default values is empty
 if_alias_prefix=
 

--- a/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/storage_ids.conf
+++ b/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/storage_ids.conf
@@ -3,7 +3,7 @@
 # id is a natural number (1, 2, 3 etc.),
 # 6 bits of the id length is enough, such as 100001
 #
-# storage ip or hostname can be dual IPs seperated by comma,
+# storage ip or hostname can be dual IPs separated by comma,
 # one is an inner (intranet) IP and another is an outer (extranet) IP,
 # or two different types of inner (intranet) IPs
 # for example: 192.168.2.100,122.244.141.46

--- a/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/tracker.conf
+++ b/docker/dockerfile_local-v6.0.9/fastdfs-conf/conf/tracker.conf
@@ -255,7 +255,7 @@ storage_ids_filename = storage_ids.conf
 # id type of the storage server in the filename, values are:
 ## ip: the ip address of the storage server
 ## id: the server id of the storage server
-# this paramter is valid only when use_storage_id set to true
+# this parameter is valid only when use_storage_id set to true
 # default value is ip
 # since V4.03
 id_type_in_filename = id

--- a/docker/dockerfile_local-v6.0.9/fastdfs自定义镜像和安装手册.txt
+++ b/docker/dockerfile_local-v6.0.9/fastdfs自定义镜像和安装手册.txt
@@ -34,7 +34,7 @@ https://github.com/ygqygq2/fastdfs-nginx/blob/master/Dockerfile
 + reserved_storage_space storage为系统其他应用留的空间，可以用绝对值（10 G或10240 M）或者百分比（V4开始支持百分比方式），网友说“最小阀值不要设置2%(有坑），设置5%可以”。
   ## 同组中只要有一台服务器达到这个标准了，就不能上传文件了
   ## no unit for byte(B) 不加单位默认是byte，例如2G=2147483648byte，reserved_storage_space = 2147483648byte
-  ## 经实践6.08版本配置百分比可以；绝对值不加单位默认byte可以；绝对值加单位报错（v6.0.9中修复了） ERROR - file: shared_func.c, line: 2449, unkown byte unit:  MB, input string: 10240 MB 
+  ## 经实践6.08版本配置百分比可以；绝对值不加单位默认byte可以；绝对值加单位报错（v6.0.9中修复了） ERROR - file: shared_func.c, line: 2449, unknown byte unit:  MB, input string: 10240 MB 
   ## 预留空间配置为绝对值，数值和单位之间不能有空格。
 
 ...请阅读参数说明，调优其他参数

--- a/docker/dockerfile_local/conf/mod_fastdfs.conf
+++ b/docker/dockerfile_local/conf/mod_fastdfs.conf
@@ -84,7 +84,7 @@ response_mode=proxy
 
 # the NIC alias prefix, such as eth in Linux, you can see it by ifconfig -a
 # multi aliases split by comma. empty value means auto set by OS type
-# this paramter used to get all ip address of the local host
+# this parameter used to get all ip address of the local host
 # default values is empty
 if_alias_prefix=
 

--- a/docker/dockerfile_local/conf/tracker.conf
+++ b/docker/dockerfile_local/conf/tracker.conf
@@ -214,7 +214,7 @@ storage_ids_filename = storage_ids.conf
 # id type of the storage server in the filename, values are:
 ## ip: the ip address of the storage server
 ## id: the server id of the storage server
-# this paramter is valid only when use_storage_id set to true
+# this parameter is valid only when use_storage_id set to true
 # default value is ip
 # since V4.03
 id_type_in_filename = ip

--- a/docker/dockerfile_network/conf/mod_fastdfs.conf
+++ b/docker/dockerfile_network/conf/mod_fastdfs.conf
@@ -84,7 +84,7 @@ response_mode=proxy
 
 # the NIC alias prefix, such as eth in Linux, you can see it by ifconfig -a
 # multi aliases split by comma. empty value means auto set by OS type
-# this paramter used to get all ip address of the local host
+# this parameter used to get all ip address of the local host
 # default values is empty
 if_alias_prefix=
 

--- a/docker/dockerfile_network/conf/tracker.conf
+++ b/docker/dockerfile_network/conf/tracker.conf
@@ -214,7 +214,7 @@ storage_ids_filename = storage_ids.conf
 # id type of the storage server in the filename, values are:
 ## ip: the ip address of the storage server
 ## id: the server id of the storage server
-# this paramter is valid only when use_storage_id set to true
+# this parameter is valid only when use_storage_id set to true
 # default value is ip
 # since V4.03
 id_type_in_filename = ip


### PR DESCRIPTION
# Fix Typos in Documentation and Configuration Files

## Summary
Fixed multiple typos found in documentation and configuration files throughout the project.

## Changes Made

### Documentation Files
- **README.md**
  - Fixed `storarge` → `storage`
  - Fixed `insufficiency` → `insufficient`

- **INSTALL**
  - Fixed `ocur` → `occur` (2 occurrences)
  - Fixed `stoarge` → `storage`

- **HISTORY**
  - Fixed `paramter` → `parameter`

### Docker Configuration Files
- **storage_ids.conf** (3 files)
  - Fixed `seperated` → `separated`

- **tracker.conf** (5 files)
  - Fixed `paramter` → `parameter`

- **mod_fastdfs.conf** (5 files)
  - Fixed `paramter` → `parameter`

- **fastdfs自定义镜像和安装手册.txt**
  - Fixed `unkown` → `unknown`

## Files Changed
- 17 files total
- 20 insertions(+), 20 deletions(-)

## Impact
- No functional changes
- Improves documentation quality and readability
- All typos corrected to proper English spelling

Contribution by Gittensor, learn more at https://gittensor.io/